### PR TITLE
Offline Support for No Ban Mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -69,6 +73,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.18.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.quazar.offlinemanager</groupId>
+            <artifactId>api</artifactId>
+            <version>3.1.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/kadotcom/lifestolen/Events/ChatEvent.java
+++ b/src/main/java/me/kadotcom/lifestolen/Events/ChatEvent.java
@@ -1,18 +1,10 @@
 package me.kadotcom.lifestolen.Events;
 
 import me.kadotcom.lifestolen.LifeStolen;
-import me.kadotcom.lifestolen.Managers.BanManager;
-import me.kadotcom.lifestolen.Managers.GameModeManager;
-import me.kadotcom.lifestolen.Managers.HealthManager;
-import org.bukkit.*;
-import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.entity.Player;
+import me.kadotcom.lifestolen.Managers.ReviveManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerChatEvent;
-
-import java.util.Objects;
 
 public class ChatEvent implements Listener {
 
@@ -21,51 +13,14 @@ public class ChatEvent implements Listener {
         plugin = ls;
     }
 
-
+    @SuppressWarnings("deprecation")
     @EventHandler
-    public void onChat(PlayerChatEvent event){
-        if(ItemEvent.players.contains(event.getPlayer())){
+    public void onChat(PlayerChatEvent event) {
+        if (ItemEvent.players.contains(event.getPlayer())) {
+        	String playerName = event.getMessage();
+        	new ReviveManager(plugin).revivePlayer(event.getPlayer(), playerName);
 
-            OfflinePlayer sName = Bukkit.getOfflinePlayer(event.getMessage());
-            Player sName2 = Bukkit.getPlayer(event.getMessage());
-
-            if(sName != null || sName.hasPlayedBefore()){
-                if(plugin.getConfig().getBoolean("death.banOnDeath")){
-                    if(Bukkit.getBanList(BanList.Type.NAME).isBanned(sName.getName())){
-                        BanManager.unban(sName);
-                        ItemEvent.players.remove(event.getPlayer());
-                        event.getPlayer().sendMessage("You revived " + sName.getName() + ".");
-                    }else {
-                        event.getPlayer().sendMessage("Player you mentioned isn't banned.");
-                        ItemEvent.players.remove(event.getPlayer());
-
-                    }
-                }
-
-
-            }else {
-                ItemEvent.players.remove(event.getPlayer());
-                event.getPlayer().sendMessage("Mention a player that has joined.");
-            }
-
-            if(sName2 != null){
-                if(!plugin.getConfig().getBoolean("death.banOnDeath")){
-                    if(sName2.getGameMode() == GameMode.SPECTATOR){
-                        ItemEvent.players.remove(event.getPlayer());
-                        ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
-                        String command = "gamemode survival " + sName2.getName();
-                        String command2 = "tp " + sName2.getName() + " " + Bukkit.getServer().getWorlds().get(0).getSpawnLocation().getX() + " " + Bukkit.getServer().getWorlds().get(0).getSpawnLocation().getY() + " " + Bukkit.getServer().getWorlds().get(0).getSpawnLocation().getZ();
-
-                        Bukkit.dispatchCommand(console, command);
-                        Bukkit.dispatchCommand(console, command2);
-
-                    }else {
-                        ItemEvent.players.remove(event.getPlayer());
-                        event.getPlayer().sendMessage("Mention a player that is dead.");
-                    }
-                }
-            }
-
+            ItemEvent.players.remove(event.getPlayer());
             event.setCancelled(true);
         }
     }

--- a/src/main/java/me/kadotcom/lifestolen/Events/ChatEvent.java
+++ b/src/main/java/me/kadotcom/lifestolen/Events/ChatEvent.java
@@ -17,8 +17,8 @@ public class ChatEvent implements Listener {
     @EventHandler
     public void onChat(PlayerChatEvent event) {
         if (ItemEvent.players.contains(event.getPlayer())) {
-        	String playerName = event.getMessage();
-        	new ReviveManager(plugin).revivePlayer(event.getPlayer(), playerName);
+            String playerName = event.getMessage();
+            new ReviveManager(plugin).revivePlayer(event.getPlayer(), playerName);
 
             ItemEvent.players.remove(event.getPlayer());
             event.setCancelled(true);

--- a/src/main/java/me/kadotcom/lifestolen/LifeStolen.java
+++ b/src/main/java/me/kadotcom/lifestolen/LifeStolen.java
@@ -7,12 +7,16 @@ import me.kadotcom.lifestolen.Events.ItemEvent;
 import me.kadotcom.lifestolen.Events.LifeStealEvent;
 import me.kadotcom.lifestolen.Managers.ItemManager;
 import net.md_5.bungee.api.chat.ClickEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import me.kadotcom.lifestolen.Utils.HTTP;
+import net.quazar.offlinemanager.api.OfflineManagerAPI;
 
 import java.util.logging.Logger;
 
 public final class LifeStolen extends JavaPlugin {
+    public static OfflineManagerAPI OfflineManagerAPI;
     private Logger log;
 
     @Override
@@ -30,6 +34,12 @@ public final class LifeStolen extends JavaPlugin {
         }
         getConfig().options().copyDefaults();
         saveDefaultConfig();
+        
+        // Load OfflineManager API if possible.
+        Plugin plugin = Bukkit.getPluginManager().getPlugin("OfflineManager");
+        if (plugin != null) {
+        	OfflineManagerAPI = (OfflineManagerAPI) plugin;
+        }
 
         ItemManager.init();
     }

--- a/src/main/java/me/kadotcom/lifestolen/LifeStolen.java
+++ b/src/main/java/me/kadotcom/lifestolen/LifeStolen.java
@@ -38,7 +38,8 @@ public final class LifeStolen extends JavaPlugin {
         // Load OfflineManager API if possible.
         Plugin plugin = Bukkit.getPluginManager().getPlugin("OfflineManager");
         if (plugin != null) {
-        	OfflineManagerAPI = (OfflineManagerAPI) plugin;
+            log.info("OfflineManager API enabled.");
+            OfflineManagerAPI = (OfflineManagerAPI) plugin;
         }
 
         ItemManager.init();

--- a/src/main/java/me/kadotcom/lifestolen/Managers/ReviveManager.java
+++ b/src/main/java/me/kadotcom/lifestolen/Managers/ReviveManager.java
@@ -1,0 +1,76 @@
+package me.kadotcom.lifestolen.Managers;
+
+import org.bukkit.BanList;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+
+import me.kadotcom.lifestolen.LifeStolen;
+import net.quazar.offlinemanager.api.data.entity.IPlayerData;
+
+public class ReviveManager {
+    LifeStolen plugin;
+    public ReviveManager(LifeStolen ls) {
+        plugin = ls;
+    }
+	
+	public void revivePlayer(Player caller, String playerName) {
+		if (plugin.getConfig().getBoolean("death.banOnDeath")) {
+            OfflinePlayer sName = Bukkit.getOfflinePlayer(playerName);
+            
+            if (sName != null) {
+                if (!sName.hasPlayedBefore()) {
+                	caller.sendMessage("Mention a player that has joined.");
+                } else if (Bukkit.getBanList(BanList.Type.NAME).isBanned(sName.getName())) {
+                    BanManager.unban(sName);
+
+                    caller.sendMessage("You revived " + sName.getName() + ".");
+                } else {
+                	caller.sendMessage("Player you mentioned isn't banned.");
+                }
+            }
+        } else {
+            Player sName = Bukkit.getPlayer(playerName);
+            
+            if (sName != null) {
+                if (sName.getGameMode() == GameMode.SPECTATOR){
+                	World world = Bukkit.getServer().getWorlds().get(0);
+        			Location spawn = world.getSpawnLocation();
+                    ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
+                    String command = "gamemode survival " + sName.getName();
+                    String command2 = "tp " + sName.getName() + " " + spawn.getX() + " " + spawn.getY() + " " + spawn.getZ();
+
+                    Bukkit.dispatchCommand(console, command);
+                    Bukkit.dispatchCommand(console, command2);
+
+                } else {
+                	caller.sendMessage("Mention a player that is dead.");
+                }
+            } else {
+            	if (LifeStolen.OfflineManagerAPI != null) {
+            		if (!LifeStolen.OfflineManagerAPI.getStorage().hasPlayer(playerName)) {
+            			caller.sendMessage("Mention a player that has joined.");
+            		} else {
+            			IPlayerData playerData = LifeStolen.OfflineManagerAPI.getPlayerData(playerName);
+            			GameMode gameMode = playerData.getGameMode();
+            			World world = Bukkit.getServer().getWorlds().get(0);
+            			Location spawn = world.getSpawnLocation();
+            			
+            			if (gameMode == GameMode.SPECTATOR) {
+            				playerData.setGameMode(GameMode.SURVIVAL);
+            				playerData.setLocation(new Location(world, spawn.getX(), spawn.getY(), spawn.getZ()));
+            			} else {
+            				caller.sendMessage("Mention a player that is dead.");
+            			}
+            		}
+            	} else {
+            		caller.sendMessage("Offline players cannot be resurrected.");
+            	}
+            }
+        }
+	}
+}

--- a/src/main/java/me/kadotcom/lifestolen/Managers/ReviveManager.java
+++ b/src/main/java/me/kadotcom/lifestolen/Managers/ReviveManager.java
@@ -63,6 +63,7 @@ public class ReviveManager {
             			if (gameMode == GameMode.SPECTATOR) {
             				playerData.setGameMode(GameMode.SURVIVAL);
             				playerData.setLocation(new Location(world, spawn.getX(), spawn.getY(), spawn.getZ()));
+            				playerData.save();
             			} else {
             				caller.sendMessage("Mention a player that is dead.");
             			}

--- a/src/main/java/me/kadotcom/lifestolen/Managers/ReviveManager.java
+++ b/src/main/java/me/kadotcom/lifestolen/Managers/ReviveManager.java
@@ -17,29 +17,29 @@ public class ReviveManager {
     public ReviveManager(LifeStolen ls) {
         plugin = ls;
     }
-	
-	public void revivePlayer(Player caller, String playerName) {
-		if (plugin.getConfig().getBoolean("death.banOnDeath")) {
+
+    public void revivePlayer(Player caller, String playerName) {
+        if (plugin.getConfig().getBoolean("death.banOnDeath")) {
             OfflinePlayer sName = Bukkit.getOfflinePlayer(playerName);
-            
+
             if (sName != null) {
                 if (!sName.hasPlayedBefore()) {
-                	caller.sendMessage("Mention a player that has joined.");
+                    caller.sendMessage("Mention a player that has joined.");
                 } else if (Bukkit.getBanList(BanList.Type.NAME).isBanned(sName.getName())) {
                     BanManager.unban(sName);
 
                     caller.sendMessage("You revived " + sName.getName() + ".");
                 } else {
-                	caller.sendMessage("Player you mentioned isn't banned.");
+                    caller.sendMessage("Player you mentioned isn't banned.");
                 }
             }
         } else {
             Player sName = Bukkit.getPlayer(playerName);
-            
+
             if (sName != null) {
                 if (sName.getGameMode() == GameMode.SPECTATOR){
-                	World world = Bukkit.getServer().getWorlds().get(0);
-        			Location spawn = world.getSpawnLocation();
+                    World world = Bukkit.getServer().getWorlds().get(0);
+                    Location spawn = world.getSpawnLocation();
                     ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
                     String command = "gamemode survival " + sName.getName();
                     String command2 = "tp " + sName.getName() + " " + spawn.getX() + " " + spawn.getY() + " " + spawn.getZ();
@@ -48,30 +48,30 @@ public class ReviveManager {
                     Bukkit.dispatchCommand(console, command2);
 
                 } else {
-                	caller.sendMessage("Mention a player that is dead.");
+                    caller.sendMessage("Mention a player that is dead.");
                 }
             } else {
-            	if (LifeStolen.OfflineManagerAPI != null) {
-            		if (!LifeStolen.OfflineManagerAPI.getStorage().hasPlayer(playerName)) {
-            			caller.sendMessage("Mention a player that has joined.");
-            		} else {
-            			IPlayerData playerData = LifeStolen.OfflineManagerAPI.getPlayerData(playerName);
-            			GameMode gameMode = playerData.getGameMode();
-            			World world = Bukkit.getServer().getWorlds().get(0);
-            			Location spawn = world.getSpawnLocation();
-            			
-            			if (gameMode == GameMode.SPECTATOR) {
-            				playerData.setGameMode(GameMode.SURVIVAL);
-            				playerData.setLocation(new Location(world, spawn.getX(), spawn.getY(), spawn.getZ()));
-            				playerData.save();
-            			} else {
-            				caller.sendMessage("Mention a player that is dead.");
-            			}
-            		}
-            	} else {
-            		caller.sendMessage("Offline players cannot be resurrected.");
-            	}
+                if (LifeStolen.OfflineManagerAPI != null) {
+                    if (!LifeStolen.OfflineManagerAPI.getStorage().hasPlayer(playerName)) {
+                        caller.sendMessage("Mention a player that has joined.");
+                    } else {
+                        IPlayerData playerData = LifeStolen.OfflineManagerAPI.getPlayerData(playerName);
+                        GameMode gameMode = playerData.getGameMode();
+                        World world = Bukkit.getServer().getWorlds().get(0);
+                        Location spawn = world.getSpawnLocation();
+
+                        if (gameMode == GameMode.SPECTATOR) {
+                            playerData.setGameMode(GameMode.SURVIVAL);
+                            playerData.setLocation(new Location(world, spawn.getX(), spawn.getY(), spawn.getZ()));
+                            playerData.save();
+                        } else {
+                            caller.sendMessage("Mention a player that is dead.");
+                        }
+                    }
+                } else {
+                    caller.sendMessage("Offline players cannot be resurrected.");
+                }
             }
         }
-	}
+    }
 }


### PR DESCRIPTION
This adds in offline support via [OfflineManager](https://github.com/SQuazar/OfflineManager) (disabled if OfflineManager isn't loaded). Now if a player revives another while they're offline (and they're not using bans), the reviver item doesn't go to waste.