### PR TITLE
Fix No Argument Withdraw

### DIFF
--- a/src/main/java/me/kadotcom/lifestolen/Commands/Withdraw.java
+++ b/src/main/java/me/kadotcom/lifestolen/Commands/Withdraw.java
@@ -36,10 +36,12 @@ import org.bukkit.entity.Player;
     }
 
     public void checkAndRun(String[] args, Player p){
-        if(args[0] == null){
-            if(HealthManager.getMaxHealth(p) > 2.0){
+        if (args.length == 0) {
+            if (HealthManager.getMaxHealth(p) > 2.0) {
                 HealthManager.setMaxHealth(HealthManager.getMaxHealth(p) - 2, p);
                 p.getInventory().addItem(ItemManager.heart);
+            } else {
+                p.sendMessage("§f[§cLifeStolen§f] You don't have enough hearts to withdraw.");
             }
         }else{
             try {


### PR DESCRIPTION
Currently `/withdraw` displays an error. It's related to this code:

```java
if(args[0] == null){
```

If there aren't enough arguments, there will be no `args[0]`, so it throws an error. The proper fix is this:

```java
if (args.length == 0) {
```

This implements that fix, and also displays an error if the action cannot be performed.