### PR TITLE
Only do HTTP calls if player has perms, only do one

### DIFF
--- a/src/main/java/me/kadotcom/lifestolen/Events/LifeStealEvent.java
+++ b/src/main/java/me/kadotcom/lifestolen/Events/LifeStealEvent.java
@@ -119,9 +119,10 @@ public class LifeStealEvent implements Listener {
             HealthManager.setMaxHealth(plugin.getConfig().getInt("HP.startHP"), event.getPlayer());
         }
 
-        if(!HTTP.get("https://api.spigotmc.org/legacy/update.php?resource=99220").equalsIgnoreCase(plugin.getDescription().getVersion()) && !plugin.getDescription().getVersion().contains("Tested")){
-            if(event.getPlayer().isOp() || event.getPlayer().hasPermission(plugin.getConfig().getString("permissions.messages.outdatedPermissionMessage"))){
-                event.getPlayer().sendMessage("§f[§cLifeStolen§f] There is a new version of LifeStolen.\nYou are on "+ plugin.getDescription().getVersion() +" while the newest version is " + HTTP.get("https://api.spigotmc.org/legacy/update.php?resource=99220") + ".\nYou can get the newest version here. https://www.spigotmc.org/resources/lifestolen.99220/");
+        if(event.getPlayer().isOp() || event.getPlayer().hasPermission(plugin.getConfig().getString("permissions.messages.outdatedPermissionMessage"))){
+            String version = HTTP.get("https://api.spigotmc.org/legacy/update.php?resource=99220");
+            if(!version.equalsIgnoreCase(plugin.getDescription().getVersion()) && !plugin.getDescription().getVersion().contains("Tested")){
+                event.getPlayer().sendMessage("§f[§cLifeStolen§f] There is a new version of LifeStolen.\nYou are on "+ plugin.getDescription().getVersion() +" while the newest version is " + version + ".\nYou can get the newest version here. https://www.spigotmc.org/resources/lifestolen.99220/");
             }
         }
 


### PR DESCRIPTION
Right now every time a user connects an HTTP request happens. If the user has op and LifeStolen is outdated, two happen. This changes it to only one request if a staff member connects.